### PR TITLE
Feat: Object Permissions

### DIFF
--- a/soundcloud/comment/models.py
+++ b/soundcloud/comment/models.py
@@ -1,7 +1,16 @@
 from django.db import models
 from django.contrib.auth import get_user_model
-from django.db.models.fields import related
+from soundcloud.utils import assign_object_perms
 from track.models import Track
+
+
+class CustomCommentManager(models.Manager):
+
+    def create(self, **kwargs):
+        instance = super().create(**kwargs)
+        assign_object_perms(instance.writer, instance)
+
+        return instance
 
 
 class Comment(models.Model):
@@ -11,3 +20,5 @@ class Comment(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     commented_at = models.TimeField(auto_now_add=True)
     parent_comment = models.OneToOneField('self', null=True, related_name="reply", on_delete=models.SET_NULL) ##linkedlist
+
+    objects = CustomCommentManager()

--- a/soundcloud/comment/views.py
+++ b/soundcloud/comment/views.py
@@ -3,6 +3,7 @@ from rest_framework.generics import get_object_or_404
 from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from comment.models import Comment
 from comment.serializers import TrackCommentSerializer
+from soundcloud.utils import CustomObjectPermissions
 from track.models import Track
 
 @extend_schema_view(
@@ -37,6 +38,7 @@ class CommentViewSet(mixins.CreateModelMixin,
                     viewsets.GenericViewSet):
 
     serializer_class = TrackCommentSerializer
+    permission_classes = (CustomObjectPermissions, )
     lookup_field = 'id'
     lookup_url_kwarg = 'comment_id'
 

--- a/soundcloud/track/models.py
+++ b/soundcloud/track/models.py
@@ -2,7 +2,17 @@ from django.db import models
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.fields import GenericRelation
 from reaction.models import Like, Repost
+from soundcloud.utils import assign_object_perms
 from tag.models import Tag
+
+
+class CustomTrackManager(models.Manager):
+
+    def create(self, **kwargs):
+        instance = super().create(**kwargs)
+        assign_object_perms(instance.artist, instance)
+
+        return instance
 
 
 class Track(models.Model):
@@ -19,6 +29,8 @@ class Track(models.Model):
     is_private = models.BooleanField(default=False)
     likes = GenericRelation(Like, related_query_name="track")
     reposts = GenericRelation(Repost, related_query_name="track")
+
+    objects = CustomTrackManager()
 
     class Meta:
         constraints = [

--- a/soundcloud/track/serializers.py
+++ b/soundcloud/track/serializers.py
@@ -92,12 +92,6 @@ class TrackSerializer(serializers.ModelSerializer):
 
         return data
 
-    def create(self, validated_data):
-        instance = super().create(validated_data=validated_data)
-        assign_object_perms(instance.artist, instance)
-
-        return instance
-    
 
 class TrackMediaUploadSerializer(MediaUploadMixin, TrackSerializer):
 


### PR DESCRIPTION
유저에게 객체에 대한 권한을 부여하는 로직을 serializer에서 model manager로 옮겼습니다.

`DELETE /tracks/{track_id}/comments/{comment_id}`에서도 객체 권한을 검사합니다.