### PR TITLE
Feat: comments pagination & response body

### DIFF
--- a/soundcloud/comment/serializers.py
+++ b/soundcloud/comment/serializers.py
@@ -57,7 +57,7 @@ class TrackCommentSerializer(serializers.ModelSerializer):
         while child_comment:
             replies.append(child_comment.id)
             child_comment = getattr(child_comment, 'reply', None)
-        return SimpleTrackCommentSerializer(Comment.objects.filter(id__in=replies), many=True).data
+        return SimpleTrackCommentSerializer(Comment.objects.filter(id__in=replies).order_by('created_at'), many=True).data
 
     def delete(self):
         current_comment = self.instance

--- a/soundcloud/comment/serializers.py
+++ b/soundcloud/comment/serializers.py
@@ -9,6 +9,7 @@ class TrackCommentSerializer(serializers.ModelSerializer):
 
     writer = SimpleUserSerializer(read_only=True)
     parent_id = serializers.IntegerField(required=False, allow_null=True, write_only=True)
+    children = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = Comment
@@ -20,6 +21,7 @@ class TrackCommentSerializer(serializers.ModelSerializer):
             'commented_at',
             'parent_id',
             'parent_comment',
+            'children',
         )
         read_only_fields = (
             'created_at',
@@ -49,6 +51,14 @@ class TrackCommentSerializer(serializers.ModelSerializer):
 
         return data
 
+    def get_children(self, comment):
+        replies = []
+        child_comment = getattr(comment, 'reply', None)
+        while child_comment:
+            replies.append(child_comment.id)
+            child_comment = getattr(child_comment, 'reply', None)
+        return SimpleTrackCommentSerializer(Comment.objects.filter(id__in=replies), many=True).data
+
     def delete(self):
         current_comment = self.instance
         parent_comment = getattr(current_comment, 'parent_comment', None)
@@ -58,6 +68,21 @@ class TrackCommentSerializer(serializers.ModelSerializer):
         if child_comment:
             child_comment.parent_comment = parent_comment
             child_comment.save()
+
+
+class SimpleTrackCommentSerializer(serializers.ModelSerializer):
+    writer = SimpleUserSerializer(read_only=True)
+
+    class Meta:
+        model = Comment
+        fields = (
+            'id',
+            'writer',
+            'content',
+            'created_at',
+            'commented_at',
+            'parent_comment',
+        )
 
 
 class UserCommentSerializer(serializers.ModelSerializer):

--- a/soundcloud/comment/views.py
+++ b/soundcloud/comment/views.py
@@ -47,7 +47,7 @@ class CommentViewSet(mixins.CreateModelMixin,
         self.track = track
 
         if self.action in ['list']:
-            self.queryset = Comment.objects.filter(track=track, parent_comment=None).order_by('-id').select_related('writer').prefetch_related('writer__followers', 'writer__owned_tracks')
+            self.queryset = Comment.objects.filter(track=track, parent_comment=None).order_by('-created_at').select_related('writer').prefetch_related('writer__followers', 'writer__owned_tracks')
         else:
             self.queryset = Comment.objects.filter(track=track).select_related('writer').prefetch_related('writer__followers', 'writer__owned_tracks')
 

--- a/soundcloud/comment/views.py
+++ b/soundcloud/comment/views.py
@@ -33,9 +33,9 @@ from track.models import Track
     ),
 )
 class CommentViewSet(mixins.CreateModelMixin,
-                    mixins.ListModelMixin,
-                    mixins.DestroyModelMixin,
-                    viewsets.GenericViewSet):
+                     mixins.ListModelMixin,
+                     mixins.DestroyModelMixin,
+                     viewsets.GenericViewSet):
 
     serializer_class = TrackCommentSerializer
     permission_classes = (CustomObjectPermissions, )
@@ -44,8 +44,12 @@ class CommentViewSet(mixins.CreateModelMixin,
 
     def get_queryset(self):
         track = getattr(self, 'track', None) or get_object_or_404(Track, id=self.kwargs['track_id'])
-        self.queryset = Comment.objects.filter(track=track).select_related('writer').prefetch_related('writer__followers', 'writer__owned_tracks')
         self.track = track
+
+        if self.action in ['list']:
+            self.queryset = Comment.objects.filter(track=track, parent_comment=None).order_by('-id').select_related('writer').prefetch_related('writer__followers', 'writer__owned_tracks')
+        else:
+            self.queryset = Comment.objects.filter(track=track).select_related('writer').prefetch_related('writer__followers', 'writer__owned_tracks')
 
         return self.queryset
 

--- a/soundcloud/soundcloud/settings/common.py
+++ b/soundcloud/soundcloud/settings/common.py
@@ -171,6 +171,8 @@ REST_FRAMEWORK = {
     ),
 
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+    'DEFAULT_PAGINATION_CLASS': 'soundcloud.utils.CustomPagination',
+    'PAGE_SIZE': 10
 }
 
 AUTHENTICATION_BACKENDS = (

--- a/soundcloud/soundcloud/utils.py
+++ b/soundcloud/soundcloud/utils.py
@@ -1,5 +1,6 @@
 from rest_framework.exceptions import APIException, ValidationError
 from rest_framework import permissions, status
+from rest_framework.pagination import PageNumberPagination
 from django.conf import settings
 from guardian.shortcuts import assign_perm
 import boto3, os, re
@@ -172,3 +173,7 @@ class MediaUploadMixin:
     def check_filename(filename):
 
         return re.search(FILENAME_PATTERN, filename)
+
+
+class CustomPagination(PageNumberPagination):
+    page_size_query_param = 'page_size'


### PR DESCRIPTION
`GET /tracks/{track_id}/comments` API 수정했습니다. 페이지네이션 구현하였고, response body 수정하였습니다.

[슬랙](https://wafflestudio-2021-rks.slack.com/archives/C02N23KKR6W/p1641391006376700) 답변에 따라 일단은 상위 댓글만을 기준으로 페이지네이션 구현하였습니다. 상위 댓글들을 불러오는 순서는 최신순이고, 그들의 children을 불러오는 순서는 오래된순입니다.

최종적인 response body 예시는 다음과 같습니다.
```
{
  "count": 30,
  "next": "http://127.0.0.1:8000/tracks/1/comments?page=3&page_size=30",
  "previous": "http://127.0.0.1:8000/tracks/1/comments?page=1&page_size=30",
  "results": [
    {
      "id": 0,
      "writer": {
        "id": 0,
        "permalink": "string",
        "email": "user@example.com",
        "image_profile": "string",
        "follower_count": 0,
        "track_count": 0,
        "first_name": "string",
        "last_name": "string"
      },
      "content": "string",
      "created_at": "2022-01-05T15:02:19.782Z",
      "commented_at": "string",
      "parent_comment": 0,
      "children": [
        {
          "id": 0,
          "writer": {
            "id": 0,
            "permalink": "string",
            "email": "user@example.com",
            "image_profile": "string",
            "follower_count": 0,
            "track_count": 0,
            "first_name": "string",
            "last_name": "string"
          },
          "content: "string",
          "created_at": "2022-01-05T15:02:19.782Z",
          "commented_at": "string",
          "parent_comment": 0
        }
      ]
    }
  ]
}
```