### PR TITLE
Feat: User Pagination & Refactors

### DIFF
--- a/soundcloud/comment/serializers.py
+++ b/soundcloud/comment/serializers.py
@@ -57,7 +57,9 @@ class TrackCommentSerializer(serializers.ModelSerializer):
         while child_comment:
             replies.append(child_comment.id)
             child_comment = getattr(child_comment, 'reply', None)
-        return SimpleTrackCommentSerializer(Comment.objects.filter(id__in=replies).order_by('created_at'), many=True).data
+
+        queryset = Comment.objects.filter(id__in=replies).select_related('writer').prefetch_related('writer__followers', 'writer__owned_tracks').order_by('created_at')
+        return SimpleTrackCommentSerializer(queryset, many=True).data
 
     def delete(self):
         current_comment = self.instance

--- a/soundcloud/comment/views.py
+++ b/soundcloud/comment/views.py
@@ -41,16 +41,14 @@ class CommentViewSet(mixins.CreateModelMixin,
     lookup_url_kwarg = 'comment_id'
 
     def get_queryset(self):
-        track = getattr(self, 'track', None) or get_object_or_404(Track, id=self.kwargs['track_id'])
-        self.queryset = Comment.objects.filter(track=track).select_related('writer').prefetch_related('writer__followers', 'writer__owned_tracks')
-        self.track = track
+        self.track = getattr(self, 'track', None) or get_object_or_404(Track, id=self.kwargs['track_id'])
 
-        return self.queryset
+        return Comment.objects.filter(track=self.track).select_related('writer').prefetch_related('writer__followers', 'writer__owned_tracks')
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        context['queryset'] = getattr(self, 'queryset', None) or self.get_queryset()
-        context['track'] = getattr(self, 'track', None) or get_object_or_404(Track, id=self.kwargs['track_id'])
+        context['queryset'] = self.get_queryset()
+        context['track'] = getattr(self, 'track', None)
 
         return context
 

--- a/soundcloud/comment/views.py
+++ b/soundcloud/comment/views.py
@@ -46,14 +46,14 @@ class CommentViewSet(mixins.CreateModelMixin,
         self.track = getattr(self, 'track', None) or get_object_or_404(Track, id=self.kwargs['track_id'])
 
         if self.action in ['list']:
-            return Comment.objects.filter(track=track, parent_comment=None).order_by('-created_at').select_related('writer').prefetch_related('writer__followers', 'writer__owned_tracks')
+            return Comment.objects.filter(track=self.track, parent_comment=None).order_by('-created_at').select_related('writer').prefetch_related('writer__followers', 'writer__owned_tracks')
         else:
-            return Comment.objects.filter(track=track).select_related('writer').prefetch_related('writer__followers', 'writer__owned_tracks')
+            return Comment.objects.filter(track=self.track).select_related('writer').prefetch_related('writer__followers', 'writer__owned_tracks')
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
         context['queryset'] = self.get_queryset()
-        context['track'] = getattr(self, 'track', None)
+        context['track'] = self.track
 
         return context
 

--- a/soundcloud/reaction/serializers.py
+++ b/soundcloud/reaction/serializers.py
@@ -1,31 +1,8 @@
-from rest_framework import serializers
+from django.contrib.contenttypes.models import ContentType
+from rest_framework import serializers, status
+from rest_framework.exceptions import NotFound
 from reaction.models import Like, Repost
 from soundcloud.utils import ConflictError
-from rest_framework import status
-from django.contrib.contenttypes.models import ContentType
-from rest_framework.exceptions import NotFound
-
-
-class LikeSerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = Like
-        fields = '__all__'
-
-    def validate(self, data):
-        
-        return data
-
-
-class RepostSerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = Repost
-        fields = '__all__'
-
-    def validate(self, data):
-        
-        return data
 
 
 class BaseReactionService(serializers.Serializer):

--- a/soundcloud/track/serializers.py
+++ b/soundcloud/track/serializers.py
@@ -3,11 +3,10 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from rest_framework.validators import UniqueTogetherValidator
 from rest_framework.serializers import ValidationError
-from track.models import Track
-from tag.serializers import TagSerializer
-from user.serializers import UserSerializer, SimpleUserSerializer
-from reaction.serializers import LikeSerializer, RepostSerializer
 from soundcloud.utils import assign_object_perms, get_presigned_url, MediaUploadMixin
+from tag.serializers import TagSerializer
+from track.models import Track
+from user.serializers import UserSerializer, SimpleUserSerializer
 
 
 class TrackSerializer(serializers.ModelSerializer):

--- a/soundcloud/track/views.py
+++ b/soundcloud/track/views.py
@@ -1,13 +1,12 @@
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
+from django.shortcuts import get_object_or_404
 from rest_framework import viewsets
+from rest_framework.decorators import action
 from soundcloud.utils import CustomObjectPermissions
 from track.models import Track
-from user.models import User
-from reaction.models import Like, Repost
 from track.serializers import SimpleTrackSerializer, TrackSerializer, TrackMediaUploadSerializer
+from user.models import User
 from user.serializers import SimpleUserSerializer
-from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
-from rest_framework.decorators import action
-from django.shortcuts import get_object_or_404
 
 @extend_schema_view(
     create=extend_schema(
@@ -77,7 +76,6 @@ from django.shortcuts import get_object_or_404
 )
 class TrackViewSet(viewsets.ModelViewSet):
 
-    queryset = Track.objects.select_related('artist').prefetch_related('likes', 'reposts', 'comments', 'artist__followers', 'artist__owned_tracks')
     permission_classes = (CustomObjectPermissions, )
     lookup_field = 'id'
     lookup_url_kwarg = 'track_id'
@@ -85,33 +83,28 @@ class TrackViewSet(viewsets.ModelViewSet):
     def get_serializer_class(self):
         if self.action in ['create', 'update', 'partial_update']:
             return TrackMediaUploadSerializer
-        elif self.action in ['list']:
+        if self.action in ['list']:
             return SimpleTrackSerializer
-        elif self.action in ['likers', 'reposters']:
+        if self.action in ['likers', 'reposters']:
             return SimpleUserSerializer
         else:
             return TrackSerializer
 
-    @action(methods=['GET'], detail=True)
-    def likers(self, request, track_id=None):
-        get_object_or_404(self.get_queryset(), id=track_id)
+    def get_queryset(self):
+        if self.action in ['likers', 'reposters']:
+            self.track = getattr(self, 'track', None) or get_object_or_404(Track, id=self.kwargs[self.lookup_url_kwarg])
 
-        like_qs = Like.objects.filter(track=track_id).select_related('user').values('user')
-        queryset = User.objects.filter(id__in=like_qs)
+            if self.action == 'likers':
+                return User.objects.prefetch_related('followers', 'owned_tracks').filter(likes__track=self.track)
+            if self.action == 'reposters':
+                return User.objects.prefetch_related('followers', 'owned_tracks').filter(reposts__track=self.track)
+        else:
+            return Track.objects.select_related('artist').prefetch_related('likes', 'reposts', 'comments', 'artist__followers', 'artist__owned_tracks')
 
-        page = self.paginate_queryset(queryset)
-        serializer = self.get_serializer(page, many=True)
+    @action(detail=True)
+    def likers(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
 
-        return self.get_paginated_response(serializer.data)
-
-    @action(methods=['GET'], detail=True)
-    def reposters(self, request, track_id=None):
-        get_object_or_404(self.get_queryset(), id=track_id)
-
-        repost_qs = Repost.objects.filter(track=track_id).select_related('user').values('user')
-        queryset = User.objects.filter(id__in=repost_qs)
-
-        page = self.paginate_queryset(queryset)
-        serializer = self.get_serializer(page, many=True)
-
-        return self.get_paginated_response(serializer.data)
+    @action(detail=True)
+    def reposters(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)

--- a/soundcloud/user/views.py
+++ b/soundcloud/user/views.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import get_user_model, logout
-from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import status, permissions, viewsets
 from rest_framework.generics import GenericAPIView, CreateAPIView, RetrieveUpdateAPIView, get_object_or_404
 from rest_framework.response import Response
@@ -86,6 +86,10 @@ class UserLogoutView(APIView):
     ),
     followers=extend_schema(
         summary="Get User's Followers",
+        parameters=[
+            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
+            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
+        ],
         responses={
             200: OpenApiResponse(response=SimpleUserSerializer(many=True), description='OK'),
             404: OpenApiResponse(description='Not Found'),
@@ -93,6 +97,10 @@ class UserLogoutView(APIView):
     ),
     followings=extend_schema(
         summary="Get User's Followings",
+        parameters=[
+            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
+            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
+        ],
         responses={
             200: OpenApiResponse(response=SimpleUserSerializer(many=True), description='OK'),
             404: OpenApiResponse(description='Not Found'),
@@ -100,6 +108,10 @@ class UserLogoutView(APIView):
     ),
     tracks=extend_schema(
         summary="Get User's Tracks",
+        parameters=[
+            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
+            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
+        ],
         responses={
             200: OpenApiResponse(response=UserTrackSerializer(many=True), description='OK'),
             404: OpenApiResponse(description='Not Found'),
@@ -107,6 +119,10 @@ class UserLogoutView(APIView):
     ),
     likes_tracks=extend_schema(
         summary="Get User's Liked Tracks",
+        parameters=[
+            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
+            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
+        ],
         responses={
             200: OpenApiResponse(response=SimpleTrackSerializer(many=True), description='OK'),
             404: OpenApiResponse(description='Not Found'),
@@ -114,6 +130,10 @@ class UserLogoutView(APIView):
     ),
     reposts_tracks=extend_schema(
         summary="Get User's Reposted Tracks",
+        parameters=[
+            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
+            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
+        ],
         responses={
             200: OpenApiResponse(response=SimpleTrackSerializer(many=True), description='OK'),
             404: OpenApiResponse(description='Not Found'),
@@ -121,6 +141,10 @@ class UserLogoutView(APIView):
     ),
     comments=extend_schema(
         summary="Get User's Comments",
+        parameters=[
+            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
+            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
+        ],
         responses={
             200: OpenApiResponse(response=UserCommentSerializer(many=True), description='OK'),
             404: OpenApiResponse(description='Not Found'),
@@ -129,6 +153,8 @@ class UserLogoutView(APIView):
 )
 class UserViewSet(viewsets.ReadOnlyModelViewSet):
 
+    serializer_class = UserSerializer
+    queryset = User.objects.all()
     lookup_field = 'id'
     lookup_url_kwarg = 'user_id'
 
@@ -142,7 +168,7 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
         elif self.action in [ 'comments' ]:
             return UserCommentSerializer
         else:
-            return UserSerializer
+            return super().get_serializer_class()
 
     def get_queryset(self):
         if self.action in ['followers', 'followings', 'tracks', 'likes_tracks', 'reposts_tracks', 'comments']:
@@ -164,7 +190,7 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
         if self.action in ['list']:
             return User.objects.prefetch_related('followers', 'owned_tracks')   
         else:
-            return User.objects.all()
+            return super().get_queryset()
 
     @action(detail=True)
     def followers(self, request, *args, **kwargs):
@@ -218,6 +244,7 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
 )
 class UserSelfView(RetrieveUpdateAPIView):
 
+    serializer_class = UserSerializer
     queryset = User.objects.prefetch_related('followers', 'followings', 'owned_tracks', 'comments')
     permission_classes = (permissions.IsAuthenticated, )
 
@@ -225,7 +252,7 @@ class UserSelfView(RetrieveUpdateAPIView):
         if self.request.method in [ 'PUT', 'PATCH' ]:
             return UserMediaUploadSerializer
         else:
-            return UserSerializer
+            return super().get_serializer_class()
 
     def get_object(self):
 


### PR DESCRIPTION
`UserViewSet`에 있는 6가지 extra actions에 대해서 pagination 적용했습니다. 보통은 `drf-spectacular`에서 pagination이 적용된 list면 swagger-ui에 알맞는 schema와 query parameter가 뜨는데, 이상하게도 query parameter(page, page_size)가 안 나오네요. `ListModelMixin`에서 상속받은 `list()`들은 모두 정상적으로 나옵니다. 아마 heuristic하게 action이 list인지 판단하는 것 같은데, 원인을 찾아봐야겠습니다. 일단은 번거롭지만 extra_schema에 각 query parameter들을 명시하였습니다.