### PR TITLE
Fix: not return private tracks

### DIFF
--- a/soundcloud/utility/serializers.py
+++ b/soundcloud/utility/serializers.py
@@ -10,10 +10,6 @@ from set.models import Set
 User = get_user_model()
 
 
-class ResolveSerializer(serializers.Serializer):
-    Location = serializers.CharField()
-
-
 class ResolveService(serializers.Serializer):
 
     def execute(self):

--- a/soundcloud/utility/views.py
+++ b/soundcloud/utility/views.py
@@ -4,7 +4,7 @@ from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from drf_spectacular.utils import OpenApiResponse, OpenApiParameter, extend_schema
-from utility.serializers import ResolveSerializer, ResolveService
+from utility.serializers import ResolveService
 
 User = get_user_model()
 
@@ -23,7 +23,7 @@ class ResolveView(APIView):
             )
         ],
         responses={
-            200: OpenApiResponse(response=ResolveSerializer, description='OK'),
+            302: OpenApiResponse(description='Found'),
             400: OpenApiResponse(description='Bad Request'),
             404: OpenApiResponse(description='Not Found'),
         }


### PR DESCRIPTION
[슬랙](https://wafflestudio-2021-rks.slack.com/archives/C02N23KKR6W/p1641581921077900) 논의에 따라 `GET /tracks` 시 조건에 따라 private한 트랙은 반환하지 않도록 하였습니다.

* 로그인하지 않은 경우 : 모든 is_private=True인 트랙 제외
* 로그인한 경우 : artist가 본인이 아니고 is_private=True인 트랙 제외