### PR TITLE
Feat: Bugfix

### DIFF
--- a/soundcloud/set/views.py
+++ b/soundcloud/set/views.py
@@ -167,7 +167,7 @@ class SetViewSet(viewsets.ModelViewSet):
     # 5. POST /sets/{set_id}/track/ (add track to playlist)
     # 6. DELETE /sets/{set_id}/track/ (remove track from playlist)
     @action(methods=['POST', 'DELETE'], detail=True)
-    def track(self, request, *args, **kwargs):
+    def tracks(self, request, *args, **kwargs):
         user = self.request.user #CustomObjectPerm 이 커버가능한지 확인하기 - x
         #set = self.get_object()
         try:

--- a/soundcloud/soundcloud/utils.py
+++ b/soundcloud/soundcloud/utils.py
@@ -64,9 +64,9 @@ def assign_object_perms(user, instance):
         'model_name': instance._meta.model_name
     }
 
+    assign_perm('%(app_label)s.add_%(model_name)s' % kwargs, user, instance)
     assign_perm('%(app_label)s.change_%(model_name)s' % kwargs, user, instance)
     assign_perm('%(app_label)s.delete_%(model_name)s' % kwargs, user, instance)
-    #assign_perm('%(app_label)s.add_%(model_name)s' % kwargs, user, instance)
 
 
 class CustomObjectPermissions(permissions.IsAuthenticatedOrReadOnly, permissions.DjangoObjectPermissions):

--- a/soundcloud/user/views.py
+++ b/soundcloud/user/views.py
@@ -184,7 +184,7 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
                 return User.objects.prefetch_related('followers', 'owned_tracks').filter(followers__follower=self.user)
             if self.action == 'tracks':
                 if self.request.user.is_authenticated and self.request.user == self.user:
-                    return Track.objects.select_related('artist').prefetch_related('likes', 'reposts', 'comments')
+                    return Track.objects.select_related('artist').prefetch_related('likes', 'reposts', 'comments').filter(artist=self.user)
                 else:
                     return Track.objects.exclude(is_private=True).select_related('artist').prefetch_related('likes', 'reposts', 'comments').filter(artist=self.user)
             if self.action == 'likes_tracks':
@@ -195,7 +195,7 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
                 return Comment.objects.select_related('track').filter(writer=self.user)
 
         if self.action in ['list']:
-            return User.objects.prefetch_related('followers', 'owned_tracks')   
+            return User.objects.prefetch_related('followers', 'owned_tracks')
         else:
             return super().get_queryset()
 


### PR DESCRIPTION
- `GET /users/{user_id}/tracks`에서 자신의 트랙을 조회할 시 다른 유저의 비공개 트랙도 조회되는 현상 수정
- 객체 생성 시 `POST` 권한 추가
- `POST(DELETE) /sets/{set_id}/track` -> `POST(DELETE) /sets/{set_id}/tracks`