### PR TITLE
Feat: add genre & tags

### DIFF
--- a/soundcloud/track/serializers.py
+++ b/soundcloud/track/serializers.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 from rest_framework.validators import UniqueTogetherValidator
 from rest_framework.serializers import ValidationError
 from soundcloud.utils import get_presigned_url, MediaUploadMixin
+from tag.models import Tag
 from tag.serializers import TagSerializer
 from track.models import Track
 from user.serializers import UserSerializer, SimpleUserSerializer
@@ -12,6 +13,7 @@ from reaction.models import Like, Repost
 from soundcloud.utils import assign_object_perms, get_presigned_url, MediaUploadMixin
 from django.contrib.contenttypes.models import ContentType
 
+
 class TrackSerializer(serializers.ModelSerializer):
 
     artist = UserSerializer(default=serializers.CurrentUserDefault(), read_only=True)
@@ -19,6 +21,8 @@ class TrackSerializer(serializers.ModelSerializer):
     image = serializers.SerializerMethodField()
     genre = TagSerializer(read_only=True)
     tags = TagSerializer(many=True, read_only=True)
+    genre_input = serializers.CharField(max_length=20, required=False)
+    tags_input = serializers.ListField(child=serializers.CharField(max_length=20), required=False)
     like_count = serializers.SerializerMethodField()
     repost_count = serializers.SerializerMethodField()
     comment_count = serializers.SerializerMethodField()
@@ -40,6 +44,8 @@ class TrackSerializer(serializers.ModelSerializer):
             'count',
             'genre',
             'tags',
+            'genre_input',
+            'tags_input',
             'is_private',
         )
         extra_kwargs = {
@@ -51,6 +57,8 @@ class TrackSerializer(serializers.ModelSerializer):
         read_only_fields = (
             'created_at',
             'count',
+            'genre_input',
+            'tags_input',
         )
 
         # Since 'artist' is read-only field, ModelSerializer wouldn't generate UniqueTogetherValidator automatically.
@@ -91,6 +99,15 @@ class TrackSerializer(serializers.ModelSerializer):
         # Although it has default value, should manually include 'artist' to the data because it is read-only field.
         if self.instance is None:
             data['artist'] = self.context['request'].user
+
+        if 'genre_input' in data:
+            genre, status = Tag.objects.get_or_create(name=data.pop('genre_input'))
+            data['genre'] = genre
+
+        if 'tags_input' in data:
+            tags_input = data.pop('tags_input')
+            tags = [Tag.objects.get_or_create(name=tag)[0] for tag in tags_input]
+            data['tags'] = tags
 
         return data
 

--- a/soundcloud/track/serializers.py
+++ b/soundcloud/track/serializers.py
@@ -101,13 +101,14 @@ class TrackSerializer(serializers.ModelSerializer):
             data['artist'] = self.context['request'].user
 
         if 'genre_input' in data:
-            genre, status = Tag.objects.get_or_create(name=data.pop('genre_input'))
-            data['genre'] = genre
+            genre_input = data.pop('genre_input')
+            data['genre'] = Tag.objects.get_or_create(name=genre_input)[0]
 
         if 'tags_input' in data:
+            genre = data.get('genre') or self.instance.genre
+            genre_name = genre.name if genre else ""
             tags_input = data.pop('tags_input')
-            tags = [Tag.objects.get_or_create(name=tag)[0] for tag in tags_input]
-            data['tags'] = tags
+            data['tags'] = [Tag.objects.get_or_create(name=tag)[0] for tag in tags_input if tag != genre_name]
 
         return data
 


### PR DESCRIPTION
* 트랙 create / update / partial update 시 장르 / 태그를 입력받을 수 있도록 하였습니다. 
* 장르는 하나의 string으로, 태그는 string의 list로 입력받습니다.
* 태그의 중복이 있으면 하나만 등록되며, 장르명과 같은 태그가 입력되면 빼고 등록됩니다.