### PR TITLE
Fix: TrackInSetSerializer

### DIFF
--- a/soundcloud/set/views.py
+++ b/soundcloud/set/views.py
@@ -103,7 +103,7 @@ class SetViewSet(viewsets.ModelViewSet):
             if self.action == 'reposters':
                 return User.objects.prefetch_related('followers', 'owned_sets').filter(reposts__set=self.set)
         else:
-            return Set.objects.all()
+            return Set.objects.all().prefetch_related('tracks__artist')
     
     # 1. POST /sets/ - 빈 playlist 생성 - mixin 이용
     # 2. PUT /sets/{set_id} - mixin 이용
@@ -149,8 +149,8 @@ class SetTrackViewSet(viewsets.GenericViewSet):
         context['track'] = get_object_or_404(Track, id=track_id)
         return context
     
-    # 7. POST /sets/{set_id}/track/ (add track to playlist)
-    # 8. DELETE /sets/{set_id}/track/ (remove track from playlist)
+    # 7. POST /sets/{set_id}/tracks (add track to playlist)
+    # 8. DELETE /sets/{set_id}/tracks (remove track from playlist)
     @action(methods=['POST', 'DELETE'], detail=True)
     def tracks(self, request, *args, **kwargs):
         service = self.get_serializer()

--- a/soundcloud/track/serializers.py
+++ b/soundcloud/track/serializers.py
@@ -240,6 +240,7 @@ class TrackInSetSerializer(serializers.ModelSerializer):
         fields = (
             'id',
             'title',
+            'artist',
             'artist_permalink',
             'artist_display_name',
             'permalink',

--- a/soundcloud/track/serializers.py
+++ b/soundcloud/track/serializers.py
@@ -230,6 +230,8 @@ class CommentTrackSerializer(serializers.ModelSerializer):
 class TrackInSetSerializer(serializers.ModelSerializer):
     audio = serializers.SerializerMethodField()
     image = serializers.SerializerMethodField()
+    artist_permalink = serializers.CharField(source='artist.permalink')
+    artist_display_name = serializers.CharField(source='artist.display_name')
     is_liked = serializers.SerializerMethodField(read_only=True)
     is_reposted = serializers.SerializerMethodField(read_only=True)
 
@@ -238,7 +240,8 @@ class TrackInSetSerializer(serializers.ModelSerializer):
         fields = (
             'id',
             'title',
-            'artist',
+            'artist_permalink',
+            'artist_display_name',
             'permalink',
             'audio',
             'image',
@@ -271,4 +274,4 @@ class TrackInSetSerializer(serializers.ModelSerializer):
             except Repost.DoesNotExist:
                 return False
         else: 
-            return False 
+            return False


### PR DESCRIPTION
GET /sets/{set_id}response body에서 tracks에 artist_permalink, artist_display_name 추가하였습니다. 

혹시 nested serializer 형태가 나을 것 같다면 수정하겠습니다.

TrackInSetSerializer는 GET /sets, POST /sets의 response에 사용되어서 해당 API의 response body 또한 artist_permalink, artist_display_name가 추가 되었습니다