### PR TITLE
Private Track & Set

### DIFF
--- a/soundcloud/comment/schemas.py
+++ b/soundcloud/comment/schemas.py
@@ -1,0 +1,31 @@
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
+from comment.serializers import TrackCommentSerializer
+
+
+comments_viewset_schema = extend_schema_view(
+    create=extend_schema(
+        summary="Create Comment",
+        responses={
+            201: OpenApiResponse(response=TrackCommentSerializer, description='Created'),
+            400: OpenApiResponse(description='Bad Request'),
+            401: OpenApiResponse(description='Unauthorized'),
+            404: OpenApiResponse(description='Not Found'),
+        }
+    ),
+    list=extend_schema(
+        summary="Get Comments on Track",
+        responses={
+            200: OpenApiResponse(response=TrackCommentSerializer, description='OK'),
+            404: OpenApiResponse(description='Not Found'),
+        }
+    ),
+    destroy=extend_schema(
+        summary="Delete Comment",
+        responses={
+            204: OpenApiResponse(description='No Content'),
+            401: OpenApiResponse(description='Unauthorized'),
+            403: OpenApiResponse(description='Permission Denied'),
+            404: OpenApiResponse(description='Not Found'),
+        }
+    ),
+)

--- a/soundcloud/comment/views.py
+++ b/soundcloud/comment/views.py
@@ -1,40 +1,14 @@
-from django.db.models import F
-from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import viewsets, mixins
 from rest_framework.filters import OrderingFilter
 from rest_framework.generics import get_object_or_404
 from comment.models import Comment
+from comment.schemas import *
 from comment.serializers import TrackCommentSerializer
-from soundcloud.utils import CommentPagination, CustomObjectPermissions
+from soundcloud.utils import CustomObjectPermissions
 from track.models import Track
 
-@extend_schema_view(
-    create=extend_schema(
-        summary="Create Comment",
-        responses={
-            201: OpenApiResponse(response=TrackCommentSerializer, description='Created'),
-            400: OpenApiResponse(description='Bad Request'),
-            401: OpenApiResponse(description='Unauthorized'),
-            404: OpenApiResponse(description='Not Found'),
-        }
-    ),
-    list=extend_schema(
-        summary="Get Comments on Track",
-        responses={
-            200: OpenApiResponse(response=TrackCommentSerializer, description='OK'),
-            404: OpenApiResponse(description='Not Found'),
-        }
-    ),
-    destroy=extend_schema(
-        summary="Delete Comment",
-        responses={
-            204: OpenApiResponse(description='No Content'),
-            401: OpenApiResponse(description='Unauthorized'),
-            403: OpenApiResponse(description='Permission Denied'),
-            404: OpenApiResponse(description='Not Found'),
-        }
-    ),
-)
+
+@comments_viewset_schema
 class CommentViewSet(mixins.CreateModelMixin,
                      mixins.ListModelMixin,
                      mixins.DestroyModelMixin,
@@ -44,7 +18,6 @@ class CommentViewSet(mixins.CreateModelMixin,
     permission_classes = (CustomObjectPermissions, )
     lookup_field = 'id'
     lookup_url_kwarg = 'comment_id'
-    # pagination_class = CommentPagination
     filter_backends = (OrderingFilter, )
     ordering_fields = []
     ordering = ['-group__created_at', 'created_at']

--- a/soundcloud/comment/views.py
+++ b/soundcloud/comment/views.py
@@ -31,14 +31,13 @@ class CommentViewSet(mixins.CreateModelMixin,
         self.track = getattr(self, 'track', None) or get_object_or_404(track_queryset, id=self.kwargs['track_id'])
 
         if self.action in ['list']:
-            res = Comment.objects\
+            return Comment.objects\
                 .select_related('writer')\
                 .prefetch_related('writer__followers', 'writer__owned_tracks')\
                 .filter(track=self.track)
-        else:
-            res = Comment.objects.filter(track=self.track)
 
-        return res
+        return Comment.objects.filter(track=self.track)
+
 
     def get_serializer_context(self):
         context = super().get_serializer_context()

--- a/soundcloud/comment/views.py
+++ b/soundcloud/comment/views.py
@@ -1,3 +1,4 @@
+from django.db.models import Q
 from rest_framework import viewsets, mixins
 from rest_framework.filters import OrderingFilter
 from rest_framework.generics import get_object_or_404
@@ -16,28 +17,36 @@ class CommentViewSet(mixins.CreateModelMixin,
 
     serializer_class = TrackCommentSerializer
     permission_classes = (CustomObjectPermissions, )
-    lookup_field = 'id'
     lookup_url_kwarg = 'comment_id'
     filter_backends = (OrderingFilter, )
     ordering_fields = []
     ordering = ['-group__created_at', 'created_at']
 
     def get_queryset(self):
-        self.track = getattr(self, 'track', None) or get_object_or_404(Track, id=self.kwargs['track_id'])
+        
+        # hide private tracks in the queryset
+        user = self.request.user if self.request.user.is_authenticated else None
+        track_queryset = Track.objects.exclude(~Q(artist=user) & Q(is_private=True))
+
+        self.track = getattr(self, 'track', None) or get_object_or_404(track_queryset, id=self.kwargs['track_id'])
 
         if self.action in ['list']:
-            queryset = Comment.objects\
+            res = Comment.objects\
                 .select_related('writer')\
                 .prefetch_related('writer__followers', 'writer__owned_tracks')\
                 .filter(track=self.track)
         else:
-            queryset = Comment.objects.filter(track=self.track)
+            res = Comment.objects.filter(track=self.track)
 
-        return queryset
+        return res
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        context['track'] = getattr(self, 'track', None) or get_object_or_404(Track, id=self.kwargs['track_id'])
+
+        # hide private tracks in the queryset
+        user = self.request.user if self.request.user.is_authenticated else None
+        track_queryset = Track.objects.exclude(~Q(artist=user) & Q(is_private=True))
+        context['track'] = getattr(self, 'track', None) or get_object_or_404(track_queryset, id=self.kwargs['track_id'])
 
         return context
 

--- a/soundcloud/set/schemas.py
+++ b/soundcloud/set/schemas.py
@@ -1,0 +1,88 @@
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_view, OpenApiTypes
+from set.serializers import *
+
+sets_viewset_schema = extend_schema_view( 
+    list=extend_schema(
+        summary="List of Sets",
+        responses={
+            200: OpenApiResponse(response=SimpleSetSerializer, description='OK'),
+        }
+    ),
+    create=extend_schema(
+        summary="Create Set",
+        responses={
+            201: OpenApiResponse(response=SetMediaUploadSerializer, description='Created'),
+            400: OpenApiResponse(description='Bad Request'),
+            401: OpenApiResponse(description='Unauthorized'),
+        }
+    ),
+    update=extend_schema(
+        summary="Update Set",
+        responses={
+            '200': OpenApiResponse(response=SetMediaUploadSerializer, description='OK'),
+            '400': OpenApiResponse(description='Bad Request'),
+            '401': OpenApiResponse(description='Unauthorized'),
+            '403': OpenApiResponse(description='Permission Denied'),
+            '404': OpenApiResponse(description='Not Found'),
+        }
+    ),
+    partial_update=extend_schema(
+        summary="Partial Update Set",
+        responses={
+            '200': OpenApiResponse(response=SetMediaUploadSerializer, description='OK'),
+            '400': OpenApiResponse(description='Bad Request'),
+            '401': OpenApiResponse(description='Unauthorized'),
+            '403': OpenApiResponse(description='Permission Denied'),
+            '404': OpenApiResponse(description='Not Found'),
+        }
+    ),
+    retrieve=extend_schema(
+        summary="Retrieve Set",
+        responses={
+            '200': OpenApiResponse(response=SetSerializer, description='OK'),
+            '404': OpenApiResponse(description='Not Found')
+        }
+    ),
+    destroy=extend_schema(
+        summary="Delete Set",
+        responses={
+            '204': OpenApiResponse(description='No Content'),
+            '401': OpenApiResponse(description='Unauthorized'),
+            '403': OpenApiResponse(description='Permission Denied'),
+            '404': OpenApiResponse(description='Not Found'),
+        }
+    ),
+    likers=extend_schema(
+        summary="Get Set's Likers",
+        parameters=[
+            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
+            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
+        ],
+        responses={
+            '200': OpenApiResponse(response=SimpleUserSerializer(many=True), description='OK'),
+            '404': OpenApiResponse(description='Not Found'),
+        }
+    ),
+    reposters=extend_schema(
+        summary="Get Set's Reposters",
+        parameters=[
+            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
+            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
+        ],
+        responses={
+            '200': OpenApiResponse(response=SimpleUserSerializer(many=True), description='OK'),
+            '404': OpenApiResponse(description='Not Found'),
+        }
+    )
+)
+
+sets_track_schema=extend_schema( 
+    summary="Add/Remove Track in Set",
+    responses={
+        '200': OpenApiResponse(description='OK'),
+        '400': OpenApiResponse(description="Bad Request"),
+        '401': OpenApiResponse(description='Unauthorized'),
+        '403': OpenApiResponse(description='Permission Denied'),
+        '404': OpenApiResponse(description='Not Found'),
+    }
+)

--- a/soundcloud/set/views.py
+++ b/soundcloud/set/views.py
@@ -1,91 +1,16 @@
-from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_view, OpenApiTypes
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 from set.models import Set
+from set.schemas import *
 from set.serializers import *
 from soundcloud.utils import CustomObjectPermissions
-from track.models import Track
 from user.models import User
 
 
-@extend_schema_view( 
-    list=extend_schema(
-        summary="List of Sets",
-        responses={
-            200: OpenApiResponse(response=SimpleSetSerializer, description='OK'),
-        }
-    ),
-    create=extend_schema(
-        summary="Create Set",
-        responses={
-            201: OpenApiResponse(response=SetMediaUploadSerializer, description='Created'),
-            400: OpenApiResponse(description='Bad Request'),
-            401: OpenApiResponse(description='Unauthorized'),
-        }
-    ),
-    update=extend_schema(
-        summary="Update Set",
-        responses={
-            '200': OpenApiResponse(response=SetMediaUploadSerializer, description='OK'),
-            '400': OpenApiResponse(description='Bad Request'),
-            '401': OpenApiResponse(description='Unauthorized'),
-            '403': OpenApiResponse(description='Permission Denied'),
-            '404': OpenApiResponse(description='Not Found'),
-        }
-    ),
-    partial_update=extend_schema(
-        summary="Partial Update Set",
-        responses={
-            '200': OpenApiResponse(response=SetMediaUploadSerializer, description='OK'),
-            '400': OpenApiResponse(description='Bad Request'),
-            '401': OpenApiResponse(description='Unauthorized'),
-            '403': OpenApiResponse(description='Permission Denied'),
-            '404': OpenApiResponse(description='Not Found'),
-        }
-    ),
-    retrieve=extend_schema(
-        summary="Retrieve Set",
-        responses={
-            '200': OpenApiResponse(response=SetSerializer, description='OK'),
-            '404': OpenApiResponse(description='Not Found')
-        }
-    ),
-    destroy=extend_schema(
-        summary="Delete Set",
-        responses={
-            '204': OpenApiResponse(description='No Content'),
-            '401': OpenApiResponse(description='Unauthorized'),
-            '403': OpenApiResponse(description='Permission Denied'),
-            '404': OpenApiResponse(description='Not Found'),
-        }
-    ),
-    likers=extend_schema(
-        summary="Get Set's Likers",
-        parameters=[
-            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
-            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
-        ],
-        responses={
-            '200': OpenApiResponse(response=SimpleUserSerializer(many=True), description='OK'),
-            '404': OpenApiResponse(description='Not Found'),
-        }
-    ),
-    reposters=extend_schema(
-        summary="Get Set's Reposters",
-        parameters=[
-            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
-            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
-        ],
-        responses={
-            '200': OpenApiResponse(response=SimpleUserSerializer(many=True), description='OK'),
-            '404': OpenApiResponse(description='Not Found'),
-        }
-    )
-
-)
+@sets_viewset_schema
 class SetViewSet(viewsets.ModelViewSet):
     permission_classes = (CustomObjectPermissions, )
     filter_backends = (OrderingFilter, )
@@ -128,18 +53,7 @@ class SetViewSet(viewsets.ModelViewSet):
         return super().list(request, *args, **kwargs)
 
 
-@extend_schema_view( 
-    tracks=extend_schema(
-        summary="Add/Remove Track in Set",
-        responses={
-            '200': OpenApiResponse(description='OK'),
-            '400': OpenApiResponse(description="Bad Request"),
-            '401': OpenApiResponse(description='Unauthorized'),
-            '403': OpenApiResponse(description='Permission Denied'),
-            '404': OpenApiResponse(description='Not Found'),
-        }
-    )
-)
+@sets_track_schema
 class SetTrackViewSet(viewsets.GenericViewSet): 
     permission_classes = (CustomObjectPermissions, )
     lookup_url_kwarg = 'set_id'

--- a/soundcloud/set/views.py
+++ b/soundcloud/set/views.py
@@ -39,12 +39,12 @@ class SetViewSet(viewsets.ModelViewSet):
         if self.action in ['likers', 'reposters']:
             self.set = getattr(self, 'set', None) or get_object_or_404(queryset, id=self.kwargs[self.lookup_url_kwarg])
 
-            if self.action == 'likers':
-                return User.objects.prefetch_related('followers', 'owned_tracks').filter(likes__set=self.set)
-            if self.action == 'reposters':
-                return User.objects.prefetch_related('followers', 'owned_tracks').filter(reposts__set=self.set)
-        
-        return queryset
+        querysets = {
+            'likers': User.objects.filter(likes__set=self.set),
+            'reposters': User.objects.filter(reposts__set=self.set),
+        }
+
+        return querysets.get(self.action) or queryset
     
     # 1. POST /sets/ - 빈 playlist 생성 - mixin 이용
     # 2. PUT /sets/{set_id} - mixin 이용

--- a/soundcloud/tag/views.py
+++ b/soundcloud/tag/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.

--- a/soundcloud/track/models.py
+++ b/soundcloud/track/models.py
@@ -18,11 +18,11 @@ class CustomTrackManager(models.Manager):
 
     def get_queryset(self):
 
-        return super().get_queryset().select_related('artist', 'genre').annotate(
-            play_count=Coalesce(Sum('trackhit__count', distinct=True), 0),          #  https://stackoverflow.com/a/35413920/14971231
-            like_count=Count('likes', distinct=True),
-            repost_count=Count('reposts', distinct=True),
-            comment_count=Count('comments', distinct=True),
+        return super().get_queryset().select_related('artist', 'genre').prefetch_related('tags').annotate(
+                play_count=Coalesce(Sum('trackhit__count', distinct=True), 0),                              #  https://stackoverflow.com/a/35413920/14971231
+                like_count=Count('likes', distinct=True),
+                repost_count=Count('reposts', distinct=True),
+                comment_count=Count('comments', distinct=True),
         )
 
 

--- a/soundcloud/track/schemas.py
+++ b/soundcloud/track/schemas.py
@@ -1,0 +1,89 @@
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_view
+from track.serializers import SimpleTrackSerializer, TrackSerializer, TrackMediaUploadSerializer
+from user.serializers import SimpleUserSerializer
+
+
+tracks_viewset_schema = extend_schema_view(
+    create=extend_schema(
+        summary="Create Track",
+        responses={
+            '201': OpenApiResponse(response=TrackMediaUploadSerializer, description='Created'),
+            '400': OpenApiResponse(description='Bad Request'),
+            '401': OpenApiResponse(description='Unauthorized'),
+        }
+    ),
+    retrieve=extend_schema(
+        summary="Retrieve Track",
+        responses={
+            '200': OpenApiResponse(response=TrackSerializer, description='OK'),
+            '404': OpenApiResponse(description='Not Found')
+        }
+    ),
+    update=extend_schema(
+        summary="Update Track",
+        responses={
+            '200': OpenApiResponse(response=TrackMediaUploadSerializer, description='OK'),
+            '400': OpenApiResponse(description='Bad Request'),
+            '401': OpenApiResponse(description='Unauthorized'),
+            '403': OpenApiResponse(description='Permission Denied'),
+            '404': OpenApiResponse(description='Not Found'),
+        }
+    ),
+    partial_update=extend_schema(
+        summary="Partial Update Track",
+        responses={
+            '200': OpenApiResponse(response=TrackMediaUploadSerializer, description='OK'),
+            '400': OpenApiResponse(description='Bad Request'),
+            '401': OpenApiResponse(description='Unauthorized'),
+            '403': OpenApiResponse(description='Permission Denied'),
+            '404': OpenApiResponse(description='Not Found'),
+        }
+    ),
+    destroy=extend_schema(
+        summary="Delete Track",
+        responses={
+            '204': OpenApiResponse(description='No Content'),
+            '401': OpenApiResponse(description='Unauthorized'),
+            '403': OpenApiResponse(description='Permission Denied'),
+            '404': OpenApiResponse(description='Not Found'),
+        }
+    ),
+    list=extend_schema(
+        summary="List Tracks",
+        responses={
+            '200': OpenApiResponse(response=SimpleTrackSerializer, description='OK'),
+        }
+    ),
+    likers=extend_schema(
+        summary="Get Track's Likers",
+        parameters=[
+            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
+            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
+        ],
+        responses={
+            '200': OpenApiResponse(response=SimpleUserSerializer(many=True), description='OK'),
+            '404': OpenApiResponse(description='Not Found'),
+        }
+    ),
+    reposters=extend_schema(
+        summary="Get Track's Reposters",
+        parameters=[
+            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
+            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
+        ],
+        responses={
+            '200': OpenApiResponse(response=SimpleUserSerializer(many=True), description='OK'),
+            '404': OpenApiResponse(description='Not Found'),
+        }
+    ),
+    hit=extend_schema(
+        summary="Hit Track",
+        parameters=[
+            OpenApiParameter("set_id", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A set id containing the track.'),
+        ],
+        responses={
+            '200': OpenApiResponse(description='OK'),
+        }
+    )
+)

--- a/soundcloud/track/serializers.py
+++ b/soundcloud/track/serializers.py
@@ -311,6 +311,7 @@ class TrackInSetSerializer(serializers.ModelSerializer):
             'permalink',
             'audio',
             'image',
+            'is_private',
             'is_liked',
             'is_reposted',
             'play_count',

--- a/soundcloud/track/views.py
+++ b/soundcloud/track/views.py
@@ -1,6 +1,4 @@
 from django.db.models import Q
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import viewsets, permissions
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
@@ -8,93 +6,12 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 from soundcloud.utils import CustomObjectPermissions
 from track.models import Track
+from track.schemas import tracks_viewset_schema
 from track.serializers import SimpleTrackSerializer, TrackHitService, TrackSerializer, TrackMediaUploadSerializer
 from user.models import User
 from user.serializers import SimpleUserSerializer
 
-@extend_schema_view(
-    create=extend_schema(
-        summary="Create Track",
-        responses={
-            '201': OpenApiResponse(response=TrackMediaUploadSerializer, description='Created'),
-            '400': OpenApiResponse(description='Bad Request'),
-            '401': OpenApiResponse(description='Unauthorized'),
-        }
-    ),
-    retrieve=extend_schema(
-        summary="Retrieve Track",
-        responses={
-            '200': OpenApiResponse(response=TrackSerializer, description='OK'),
-            '404': OpenApiResponse(description='Not Found')
-        }
-    ),
-    update=extend_schema(
-        summary="Update Track",
-        responses={
-            '200': OpenApiResponse(response=TrackMediaUploadSerializer, description='OK'),
-            '400': OpenApiResponse(description='Bad Request'),
-            '401': OpenApiResponse(description='Unauthorized'),
-            '403': OpenApiResponse(description='Permission Denied'),
-            '404': OpenApiResponse(description='Not Found'),
-        }
-    ),
-    partial_update=extend_schema(
-        summary="Partial Update Track",
-        responses={
-            '200': OpenApiResponse(response=TrackMediaUploadSerializer, description='OK'),
-            '400': OpenApiResponse(description='Bad Request'),
-            '401': OpenApiResponse(description='Unauthorized'),
-            '403': OpenApiResponse(description='Permission Denied'),
-            '404': OpenApiResponse(description='Not Found'),
-        }
-    ),
-    destroy=extend_schema(
-        summary="Delete Track",
-        responses={
-            '204': OpenApiResponse(description='No Content'),
-            '401': OpenApiResponse(description='Unauthorized'),
-            '403': OpenApiResponse(description='Permission Denied'),
-            '404': OpenApiResponse(description='Not Found'),
-        }
-    ),
-    list=extend_schema(
-        summary="List Tracks",
-        responses={
-            '200': OpenApiResponse(response=SimpleTrackSerializer, description='OK'),
-        }
-    ),
-    likers=extend_schema(
-        summary="Get Track's Likers",
-        parameters=[
-            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
-            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
-        ],
-        responses={
-            '200': OpenApiResponse(response=SimpleUserSerializer(many=True), description='OK'),
-            '404': OpenApiResponse(description='Not Found'),
-        }
-    ),
-    reposters=extend_schema(
-        summary="Get Track's Reposters",
-        parameters=[
-            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
-            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
-        ],
-        responses={
-            '200': OpenApiResponse(response=SimpleUserSerializer(many=True), description='OK'),
-            '404': OpenApiResponse(description='Not Found'),
-        }
-    ),
-    hit=extend_schema(
-        summary="Hit Track",
-        parameters=[
-            OpenApiParameter("set_id", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A set id containing the track.'),
-        ],
-        responses={
-            '200': OpenApiResponse(description='OK'),
-        }
-    )
-)
+@tracks_viewset_schema
 class TrackViewSet(viewsets.ModelViewSet):
 
     permission_classes = (CustomObjectPermissions, )

--- a/soundcloud/track/views.py
+++ b/soundcloud/track/views.py
@@ -43,12 +43,12 @@ class TrackViewSet(viewsets.ModelViewSet):
         if self.action in ['likers', 'reposters']:
             self.track = getattr(self, 'track', None) or get_object_or_404(queryset, pk=self.kwargs[self.lookup_url_kwarg])
 
-            if self.action == 'likers':
-                return User.objects.filter(likes__track=self.track)
-            if self.action == 'reposters':
-                return User.objects.filter(reposts__track=self.track)
+        querysets = {
+            'likers': User.objects.filter(likes__track=self.track),
+            'reposters': User.objects.filter(reposts__track=self.track),
+        }
 
-        return queryset
+        return querysets.get(self.action) or queryset
 
     @action(detail=True)
     def likers(self, request, *args, **kwargs):

--- a/soundcloud/user/schemas.py
+++ b/soundcloud/user/schemas.py
@@ -1,0 +1,211 @@
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_view
+from comment.serializers import UserCommentSerializer
+from set.serializers import SimpleSetSerializer
+from track.serializers import SimpleTrackSerializer, UserTrackSerializer
+from user.serializers import *
+
+
+auth_signup_schema = extend_schema(
+    summary="Signup",
+    tags=['auth', ],
+    responses={
+        201: OpenApiResponse(response=UserCreateSerializer, description='Created'),
+        400: OpenApiResponse(description='Bad Request'),
+        409: OpenApiResponse(description='Conflict'),
+    }
+)
+
+auth_login_schema = extend_schema(
+    summary="Login",
+    tags=['auth', ],
+    responses={
+        200: OpenApiResponse(response=UserLoginSerializer, description='OK'),
+        400: OpenApiResponse(description='Bad Request'),
+    }
+)
+
+auth_logout_schema = extend_schema(
+    summary="Logout",
+    tags=['auth', ],
+    description="Do nothing, actually.",
+    responses={
+        200: OpenApiResponse(description='OK'),
+        401: OpenApiResponse(description='Unauthorized'),
+    }
+)
+
+users_viewset_schema = extend_schema_view(
+    retrieve=extend_schema(
+        summary="Retrieve User",
+        responses={
+            200: OpenApiResponse(response=UserSerializer, description='OK'),
+            404: OpenApiResponse(description='Not Found'),
+        }
+    ),
+    list=extend_schema(
+        summary="List Users",
+        responses={
+            200: OpenApiResponse(response=SimpleUserSerializer, description='OK'),
+        }
+    ),
+    followers=extend_schema(
+        summary="Get User's Followers",
+        parameters=[
+            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
+            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
+        ],
+        responses={
+            200: OpenApiResponse(response=SimpleUserSerializer(many=True), description='OK'),
+            404: OpenApiResponse(description='Not Found'),
+        }
+    ),
+    followings=extend_schema(
+        summary="Get User's Followings",
+        parameters=[
+            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
+            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
+        ],
+        responses={
+            200: OpenApiResponse(response=SimpleUserSerializer(many=True), description='OK'),
+            404: OpenApiResponse(description='Not Found'),
+        }
+    ),
+    tracks=extend_schema(
+        summary="Get User's Tracks",
+        parameters=[
+            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
+            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
+        ],
+        responses={
+            200: OpenApiResponse(response=UserTrackSerializer(many=True), description='OK'),
+            404: OpenApiResponse(description='Not Found'),
+        }
+    ),
+    sets=extend_schema(
+        summary="Get User's sets",
+        parameters=[
+            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
+            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
+        ],
+        responses={
+            200: OpenApiResponse(response=SimpleSetSerializer(many=True), description='OK'),
+            404: OpenApiResponse(description='Not Found'),
+        }
+    ),
+    history_tracks=extend_schema(
+        summary="Get User's Track History",
+        responses={
+            200: OpenApiResponse(response=SimpleTrackSerializer(many=True), description='OK'),
+            404: OpenApiResponse(description='Not Found'),
+        }
+    ),
+    history_sets=extend_schema(
+        summary="Get User's Set History",
+        responses={
+            200: OpenApiResponse(response=SimpleSetSerializer(many=True), description='OK'),
+            404: OpenApiResponse(description='Not Found'),
+        }
+    ),
+    likes_tracks=extend_schema(
+        summary="Get User's Liked Tracks",
+        parameters=[
+            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
+            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
+        ],
+        responses={
+            200: OpenApiResponse(response=SimpleTrackSerializer(many=True), description='OK'),
+            404: OpenApiResponse(description='Not Found'),
+        }
+    ),
+    reposts_tracks=extend_schema(
+        summary="Get User's Reposted Tracks",
+        parameters=[
+            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
+            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
+        ],
+        responses={
+            200: OpenApiResponse(response=SimpleTrackSerializer(many=True), description='OK'),
+            404: OpenApiResponse(description='Not Found'),
+        }
+    ),
+    likes_sets=extend_schema(
+        summary="Get User's Liked Sets",
+        parameters=[
+            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
+            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
+        ],
+        responses={
+            200: OpenApiResponse(response=SimpleSetSerializer(many=True), description='OK'),
+            404: OpenApiResponse(description='Not Found'),
+        }
+    ),
+    reposts_sets=extend_schema(
+        summary="Get User's Reposted Sets",
+        parameters=[
+            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
+            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
+        ],
+        responses={
+            200: OpenApiResponse(response=SimpleSetSerializer(many=True), description='OK'),
+            404: OpenApiResponse(description='Not Found'),
+        }
+    ),
+    comments=extend_schema(
+        summary="Get User's Comments",
+        parameters=[
+            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
+            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
+        ],
+        responses={
+            200: OpenApiResponse(response=UserCommentSerializer(many=True), description='OK'),
+            404: OpenApiResponse(description='Not Found'),
+        }
+    ),
+)
+
+users_self_schema = extend_schema_view(
+    get=extend_schema(
+        summary="Retrieve Me",
+        responses={
+            200: OpenApiResponse(response=UserSerializer, description='OK'),
+            401: OpenApiResponse(description='Unauthorized'),
+        }
+    ),
+    put=extend_schema(
+        summary="Update Me",
+        responses={
+            200: OpenApiResponse(response=UserMediaUploadSerializer, description='OK'),
+            400: OpenApiResponse(description='Bad Request'),
+            401: OpenApiResponse(description='Unauthorized'),
+        }
+    ),
+    patch=extend_schema(
+        summary="Partial Update Me",
+        responses={
+            200: OpenApiResponse(response=UserMediaUploadSerializer, description='OK'),
+            400: OpenApiResponse(description='Bad Request'),
+            401: OpenApiResponse(description='Unauthorized'),
+        }
+    ),
+)
+
+users_follow_schema = extend_schema_view(
+  post=extend_schema(
+      summary="Follow User",
+      responses={
+          201: OpenApiResponse(description='Created'),
+          400: OpenApiResponse(description='Bad Request'),
+          401: OpenApiResponse(description='Unauthorized'),
+          404: OpenApiResponse(description='Not Found'),
+      }
+  ),
+  delete=extend_schema(
+      summary="Unfollow User",
+      responses={
+          204: OpenApiResponse(description='No Content'),
+          400: OpenApiResponse(description='Bad Request'),
+          401: OpenApiResponse(description='Unauthorized'),
+          404: OpenApiResponse(description='Not Found'),
+      }
+  ),
+)

--- a/soundcloud/user/views.py
+++ b/soundcloud/user/views.py
@@ -90,30 +90,21 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
         comment_queryset = Comment.objects \
             .exclude(~Q(track__artist=request_user) & Q(track__is_private=True))
 
-        if self.action == 'followers':
-            return User.objects.filter(followings__followee=self.user)
-        if self.action == 'followings':
-            return User.objects.filter(followers__follower=self.user)
-        if self.action == 'tracks':
-            return track_queryset.filter(artist=self.user)
-        if self.action == 'sets':
-            return set_queryset.filter(creator=self.user)
-        if self.action == 'likes_tracks':
-            return track_queryset.filter(likes__user=self.user)
-        if self.action == 'reposts_tracks':
-            return track_queryset.filter(reposts__user=self.user)
-        if self.action == 'likes_sets':
-            return set_queryset.filter(likes__user=self.user)
-        if self.action == 'reposts_sets':
-            return set_queryset.filter(reposts__user=self.user)
-        if self.action == 'history_tracks':
-            return track_queryset.filter(players=self.user)
-        if self.action == 'history_sets':
-            return set_queryset.filter(players=self.user)
-        if self.action == 'comments':
-            return comment_queryset.filter(writer=self.user)
+        querysets = {
+            'followers': User.objects.filter(followings__followee=self.user),
+            'followings': User.objects.filter(followers__follower=self.user),
+            'tracks': track_queryset.filter(artist=self.user),
+            'sets': set_queryset.filter(creator=self.user),
+            'likes_tracks': track_queryset.filter(likes__user=self.user),
+            'reposts_tracks': track_queryset.filter(reposts__user=self.user),
+            'likes_sets': set_queryset.filter(likes__user=self.user),
+            'reposts_sets': set_queryset.filter(reposts__user=self.user),
+            'history_tracks': track_queryset.filter(players=self.user),
+            'history_sets': set_queryset.filter(players=self.user),
+            'comments': comment_queryset.filter(writer=self.user),
+        }
 
-        return User.objects.all()
+        return querysets.get(self.action) or User.objects.all()
 
     @action(detail=True)
     def followers(self, request, *args, **kwargs):

--- a/soundcloud/user/views.py
+++ b/soundcloud/user/views.py
@@ -1,6 +1,4 @@
 from django.contrib.auth import get_user_model, logout
-from django.db.models import F
-from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import status, permissions, viewsets
 from rest_framework.filters import OrderingFilter
 from rest_framework.generics import GenericAPIView, CreateAPIView, RetrieveUpdateAPIView, get_object_or_404
@@ -12,22 +10,12 @@ from comment.serializers import UserCommentSerializer
 from set.models import Set
 from set.serializers import SimpleSetSerializer
 from track.serializers import SimpleTrackSerializer, UserTrackSerializer
+from user.schemas import *
 from user.serializers import *
 
 User = get_user_model()
 
-
-@extend_schema_view(
-    post=extend_schema(
-        summary="Signup",
-        tags=['auth', ],
-        responses={
-            201: OpenApiResponse(response=UserCreateSerializer, description='Created'),
-            400: OpenApiResponse(description='Bad Request'),
-            409: OpenApiResponse(description='Conflict'),
-        }
-    )
-)
+@auth_signup_schema
 class UserSignUpView(CreateAPIView):
 
     serializer_class = UserCreateSerializer
@@ -35,20 +23,13 @@ class UserSignUpView(CreateAPIView):
     permission_classes = (permissions.AllowAny, )
 
 
+@auth_login_schema
 class UserLoginView(GenericAPIView):
 
     serializer_class = UserLoginSerializer
     queryset = User.objects.all()
     permission_classes = (permissions.AllowAny, )
 
-    @extend_schema(
-        summary="Login",
-        tags=['auth', ],
-        responses={
-            200: OpenApiResponse(response=UserLoginSerializer, description='OK'),
-            400: OpenApiResponse(description='Bad Request'),
-        }
-    )
     def put(self, request):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -57,173 +38,37 @@ class UserLoginView(GenericAPIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
+@auth_logout_schema
 class UserLogoutView(APIView):
 
-    @extend_schema(
-        summary="Logout",
-        tags=['auth', ],
-        description="Do nothing, actually.",
-        responses={
-            200: OpenApiResponse(description='OK'),
-            401: OpenApiResponse(description='Unauthorized'),
-        }
-    )
     def post(self, request):
         logout(request)
         
         return Response({"You\'ve been logged out"}, status=status.HTTP_200_OK)
 
-      
-@extend_schema_view(
-    retrieve=extend_schema(
-        summary="Retrieve User",
-        responses={
-            200: OpenApiResponse(response=UserSerializer, description='OK'),
-            404: OpenApiResponse(description='Not Found'),
-        }
-    ),
-    list=extend_schema(
-        summary="List Users",
-        responses={
-            200: OpenApiResponse(response=SimpleUserSerializer, description='OK'),
-        }
-    ),
-    followers=extend_schema(
-        summary="Get User's Followers",
-        parameters=[
-            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
-            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
-        ],
-        responses={
-            200: OpenApiResponse(response=SimpleUserSerializer(many=True), description='OK'),
-            404: OpenApiResponse(description='Not Found'),
-        }
-    ),
-    followings=extend_schema(
-        summary="Get User's Followings",
-        parameters=[
-            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
-            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
-        ],
-        responses={
-            200: OpenApiResponse(response=SimpleUserSerializer(many=True), description='OK'),
-            404: OpenApiResponse(description='Not Found'),
-        }
-    ),
-    tracks=extend_schema(
-        summary="Get User's Tracks",
-        parameters=[
-            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
-            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
-        ],
-        responses={
-            200: OpenApiResponse(response=UserTrackSerializer(many=True), description='OK'),
-            404: OpenApiResponse(description='Not Found'),
-        }
-    ),
-    sets=extend_schema(
-        summary="Get User's sets",
-        parameters=[
-            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
-            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
-        ],
-        responses={
-            200: OpenApiResponse(response=SimpleSetSerializer(many=True), description='OK'),
-            404: OpenApiResponse(description='Not Found'),
-        }
-    ),
-    history_tracks=extend_schema(
-        summary="Get User's Track History",
-        responses={
-            200: OpenApiResponse(response=SimpleTrackSerializer(many=True), description='OK'),
-            404: OpenApiResponse(description='Not Found'),
-        }
-    ),
-    history_sets=extend_schema(
-        summary="Get User's Set History",
-        responses={
-            200: OpenApiResponse(response=SimpleSetSerializer(many=True), description='OK'),
-            404: OpenApiResponse(description='Not Found'),
-        }
-    ),
-    likes_tracks=extend_schema(
-        summary="Get User's Liked Tracks",
-        parameters=[
-            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
-            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
-        ],
-        responses={
-            200: OpenApiResponse(response=SimpleTrackSerializer(many=True), description='OK'),
-            404: OpenApiResponse(description='Not Found'),
-        }
-    ),
-    reposts_tracks=extend_schema(
-        summary="Get User's Reposted Tracks",
-        parameters=[
-            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
-            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
-        ],
-        responses={
-            200: OpenApiResponse(response=SimpleTrackSerializer(many=True), description='OK'),
-            404: OpenApiResponse(description='Not Found'),
-        }
-    ),
-    likes_sets=extend_schema(
-        summary="Get User's Liked Sets",
-        parameters=[
-            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
-            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
-        ],
-        responses={
-            200: OpenApiResponse(response=SimpleSetSerializer(many=True), description='OK'),
-            404: OpenApiResponse(description='Not Found'),
-        }
-    ),
-    reposts_sets=extend_schema(
-        summary="Get User's Reposted Sets",
-        parameters=[
-            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
-            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
-        ],
-        responses={
-            200: OpenApiResponse(response=SimpleSetSerializer(many=True), description='OK'),
-            404: OpenApiResponse(description='Not Found'),
-        }
-    ),
-    comments=extend_schema(
-        summary="Get User's Comments",
-        parameters=[
-            OpenApiParameter("page", OpenApiTypes.INT, OpenApiParameter.QUERY, description='A page number within the paginated result set.'),
-            OpenApiParameter("page_size", OpenApiTypes.INT, OpenApiParameter.QUERY, description='Number of results to return per page.'),
-        ],
-        responses={
-            200: OpenApiResponse(response=UserCommentSerializer(many=True), description='OK'),
-            404: OpenApiResponse(description='Not Found'),
-        }
-    ),
-)
+
+@users_viewset_schema
 class UserViewSet(viewsets.ReadOnlyModelViewSet):
 
-    serializer_class = UserSerializer
     queryset = User.objects.all()
-    lookup_field = 'id'
     lookup_url_kwarg = 'user_id'
     filter_backends = (OrderingFilter, )
     ordering_fields = ['created_at']
     ordering = ['-created_at']
 
     def get_serializer_class(self):
-        if self.action in [ 'list', 'followers', 'followings' ]:
+        if self.action in ['list', 'followers', 'followings']:
             return SimpleUserSerializer
-        if self.action in [ 'tracks' ]:
+        if self.action in ['tracks']:
             return UserTrackSerializer
-        if self.action in [ 'likes_tracks', 'reposts_tracks', 'history_tracks' ]:
+        if self.action in ['likes_tracks', 'reposts_tracks', 'history_tracks']:
             return SimpleTrackSerializer
-        if self.action in [ 'likes_sets', 'reposts_sets', 'history_sets', 'sets' ]:
+        if self.action in ['likes_sets', 'reposts_sets', 'history_sets', 'sets']:
             return SimpleSetSerializer
-        if self.action in [ 'comments' ]:
+        if self.action in ['comments']:
             return UserCommentSerializer
-        return super().get_serializer_class()
+
+        return UserSerializer
 
     def get_queryset(self):
         if self.action in ['followers', 'followings', 'tracks', 'sets', 'likes_tracks', 'reposts_tracks', 'likes_sets', 'reposts_sets', 'history_tracks', 'history_sets', 'comments']:
@@ -303,31 +148,7 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
         return super().list(request, *args, **kwargs)
 
 
-@extend_schema_view(
-    get=extend_schema(
-        summary="Retrieve Me",
-        responses={
-            200: OpenApiResponse(response=UserSerializer, description='OK'),
-            401: OpenApiResponse(description='Unauthorized'),
-        }
-    ),
-    put=extend_schema(
-        summary="Update Me",
-        responses={
-            200: OpenApiResponse(response=UserMediaUploadSerializer, description='OK'),
-            400: OpenApiResponse(description='Bad Request'),
-            401: OpenApiResponse(description='Unauthorized'),
-        }
-    ),
-    patch=extend_schema(
-        summary="Partial Update Me",
-        responses={
-            200: OpenApiResponse(response=UserMediaUploadSerializer, description='OK'),
-            400: OpenApiResponse(description='Bad Request'),
-            401: OpenApiResponse(description='Unauthorized'),
-        }
-    ),
-)
+@users_self_schema
 class UserSelfView(RetrieveUpdateAPIView):
 
     serializer_class = UserSerializer
@@ -345,6 +166,7 @@ class UserSelfView(RetrieveUpdateAPIView):
         return get_object_or_404(self.get_queryset(), id=self.request.user.id)
 
 
+@users_follow_schema
 class UserFollowView(GenericAPIView):
 
     serializer_class = UserFollowService
@@ -358,30 +180,12 @@ class UserFollowView(GenericAPIView):
 
         return context
 
-    @extend_schema(
-        summary="Follow User",
-        responses={
-            201: OpenApiResponse(description='Created'),
-            400: OpenApiResponse(description='Bad Request'),
-            401: OpenApiResponse(description='Unauthorized'),
-            404: OpenApiResponse(description='Not Found'),
-        }
-    )
     def post(self, request, *args, **kwargs):
         service = self.get_serializer()
         status, data = service.create()
 
         return Response(status=status, data=data)
 
-    @extend_schema(
-        summary="Unfollow User",
-        responses={
-            204: OpenApiResponse(description='No Content'),
-            400: OpenApiResponse(description='Bad Request'),
-            401: OpenApiResponse(description='Unauthorized'),
-            404: OpenApiResponse(description='Not Found'),
-        }
-    )
     def delete(self, request, *args, **kwargs):
         service = self.get_serializer()
         status, data = service.delete()

--- a/soundcloud/utility/schemas.py
+++ b/soundcloud/utility/schemas.py
@@ -1,0 +1,20 @@
+from drf_spectacular.utils import OpenApiResponse, OpenApiParameter, extend_schema
+
+
+resolve_schema = extend_schema(
+    summary="Resolves soundwaffle.com URLs to Resource URLs to use with the API.",
+    parameters=[
+        OpenApiParameter(
+            name="url",
+            type=str,
+            location=OpenApiParameter.QUERY,
+            description="soundwaffle.com URL",
+            required=True,
+        )
+    ],
+    responses={
+        302: OpenApiResponse(description='Found'),
+        400: OpenApiResponse(description='Bad Request'),
+        404: OpenApiResponse(description='Not Found'),
+    }
+)

--- a/soundcloud/utility/views.py
+++ b/soundcloud/utility/views.py
@@ -1,33 +1,16 @@
 from django.contrib.auth import get_user_model
-from django.shortcuts import redirect
 from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from drf_spectacular.utils import OpenApiResponse, OpenApiParameter, extend_schema
+from utility.schemas import *
 from utility.serializers import ResolveService
 
 User = get_user_model()
 
 
+@resolve_schema
 class ResolveView(APIView):
 
-    @extend_schema(
-        summary="Resolves soundwaffle.com URLs to Resource URLs to use with the API.",
-        parameters=[
-            OpenApiParameter(
-                name="url",
-                type=str,
-                location=OpenApiParameter.QUERY,
-                description="soundwaffle.com URL",
-                required=True,
-            )
-        ],
-        responses={
-            302: OpenApiResponse(description='Found'),
-            400: OpenApiResponse(description='Bad Request'),
-            404: OpenApiResponse(description='Not Found'),
-        }
-    )
     def get(self, request, *args, **kwargs):
         """
         User  : https%3A%2F%2Fsoundwaffle.com%2F{user_permalink} \n


### PR DESCRIPTION
- 모든 API에서 `is_private=True`인 트랙과 세트를 반환하지 않도록 하였습니다.
- OpenAPI 3.0 schema 관련 데코레이터들을 모듈로 분리하였습니다.
- `TrackInSetSerializer`에서 `is_private` 필드가 표시되도록 하였습니다.