### PR TITLE
Feature/search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ secrets.json
 
 # Redis Dump File
 dump.rdb
+/soundcloud/whoosh_index/

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -9,6 +9,7 @@ source venv/bin/activate
 pip3 install -r requirements.txt --quiet
 
 python3 manage.py migrate --settings=soundcloud.settings.prod
+python3 manage.py update_index --age=2 --settings=soundcloud.settings.prod
 python3 manage.py check --deploy --settings=soundcloud.settings.prod
 
 pkill -f gunicorn

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -9,7 +9,7 @@ source venv/bin/activate
 pip3 install -r requirements.txt --quiet
 
 python3 manage.py migrate --settings=soundcloud.settings.prod
-python3 manage.py update_index --settings=soundcloud.settings.prod
+python3 manage.py update_index --remove --settings=soundcloud.settings.prod
 python3 manage.py check --deploy --settings=soundcloud.settings.prod
 
 pkill -f gunicorn

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -9,7 +9,7 @@ source venv/bin/activate
 pip3 install -r requirements.txt --quiet
 
 python3 manage.py migrate --settings=soundcloud.settings.prod
-python3 manage.py update_index --age=2 --settings=soundcloud.settings.prod
+python3 manage.py update_index --settings=soundcloud.settings.prod
 python3 manage.py check --deploy --settings=soundcloud.settings.prod
 
 pkill -f gunicorn

--- a/soundcloud/requirements.txt
+++ b/soundcloud/requirements.txt
@@ -15,3 +15,5 @@ drf-spectacular
 django-guardian
 requests
 django-redis
+drf-haystack
+whoosh

--- a/soundcloud/set/search_indexes.py
+++ b/soundcloud/set/search_indexes.py
@@ -1,0 +1,14 @@
+from haystack import indexes
+from set.models import Set
+
+
+class SetIndex(indexes.SearchIndex, indexes.Indexable):
+    text = indexes.EdgeNgramField(document=True, use_template=True, template_name='search/user_text.txt')
+    id = indexes.IntegerField(model_attr='id')
+
+    def get_model(self):
+        return Set
+
+    def index_queryset(self, using=None):
+        """Used when the entire index for model is updated."""
+        return self.get_model().objects.all()

--- a/soundcloud/set/search_indexes.py
+++ b/soundcloud/set/search_indexes.py
@@ -3,7 +3,7 @@ from set.models import Set
 
 
 class SetIndex(indexes.SearchIndex, indexes.Indexable):
-    text = indexes.EdgeNgramField(document=True, use_template=True, template_name='search/user_text.txt')
+    text = indexes.EdgeNgramField(document=True, use_template=True, template_name='search/set_text.txt')
     id = indexes.IntegerField(model_attr='id')
 
     def get_model(self):

--- a/soundcloud/set/serializers.py
+++ b/soundcloud/set/serializers.py
@@ -1,5 +1,6 @@
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
+from drf_haystack.serializers import HaystackSerializerMixin
 from rest_framework import serializers, status
 from rest_framework.serializers import ValidationError
 from rest_framework.validators import UniqueTogetherValidator
@@ -11,6 +12,7 @@ from tag.serializers import TagSerializer
 from track.serializers import TrackInSetSerializer
 from user.serializers import SimpleUserSerializer
 from reaction.models import Like, Repost
+from set.search_indexes import SetIndex
 
 
 class SetSerializer(serializers.ModelSerializer):
@@ -237,6 +239,10 @@ class SetTrackService(serializers.Serializer):
         return status.HTTP_400_BAD_REQUEST, {"error": "셋에 없는 트랙입니다."}
 
 
+class SetSearchSerializer(HaystackSerializerMixin, SetSerializer):
 
+    class Meta(SetSerializer.Meta):
+        index_classes = [SetIndex]
+        search_fields = ('text', )
 
 

--- a/soundcloud/set/serializers.py
+++ b/soundcloud/set/serializers.py
@@ -1,3 +1,4 @@
+from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers, status
 from rest_framework.serializers import ValidationError

--- a/soundcloud/set/templates/search/set_text.txt
+++ b/soundcloud/set/templates/search/set_text.txt
@@ -1,0 +1,3 @@
+{{ object.title }}
+{{ object.creator }}
+{{ object.description }}

--- a/soundcloud/set/urls.py
+++ b/soundcloud/set/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path, include
 from rest_framework.routers import SimpleRouter
-from set.views import SetViewSet, SetTrackViewSet
+from set.views import SetViewSet, SetTrackViewSet, SetSearchAPIView
 
 router = SimpleRouter(trailing_slash=False)
 router.register('sets', SetViewSet, basename='sets')   # /sets
@@ -8,5 +8,6 @@ router.register('sets', SetTrackViewSet, basename='sets')
 
 
 urlpatterns = [
-    path('', include(router.urls))
+    path('', include(router.urls)),
+    path('search/sets', SetSearchAPIView.as_view(), name='search-sets'),       # /search/sets
 ]

--- a/soundcloud/set/views.py
+++ b/soundcloud/set/views.py
@@ -182,7 +182,6 @@ class SetTrackViewSet(viewsets.GenericViewSet):
 class SetSearchAPIView(ListModelMixin, HaystackGenericAPIView):
     index_models = [Set]
     serializer_class = SetSearchSerializer
-    pagination_class = None
 
     def get_queryset(self, index_models=[]):
         queryset = self.object_class()._clone()

--- a/soundcloud/soundcloud/settings/common.py
+++ b/soundcloud/soundcloud/settings/common.py
@@ -78,6 +78,7 @@ INSTALLED_APPS = [
     'tag',
     'reaction',
     'utility',
+    'haystack',
 ]
 
 MIDDLEWARE = [
@@ -237,3 +238,13 @@ CACHES = {
 
 # for Sociallogin
 SOCIAL_PASSWORD = "socialpassword"
+
+
+WHOOSH_INDEX = os.path.join(BASE_DIR, 'whoosh_index')
+
+HAYSTACK_CONNECTIONS = {
+    'default': {
+        'ENGINE': 'haystack.backends.whoosh_backend.WhooshEngine',
+        'PATH': WHOOSH_INDEX,
+    },
+}

--- a/soundcloud/track/search_indexes.py
+++ b/soundcloud/track/search_indexes.py
@@ -3,7 +3,7 @@ from track.models import Track
 
 
 class TrackIndex(indexes.SearchIndex, indexes.Indexable):
-    q = indexes.EdgeNgramField(document=True, use_template=True, template_name='search/track_text.txt')
+    text = indexes.EdgeNgramField(document=True, use_template=True, template_name='search/track_text.txt')
     id = indexes.IntegerField(model_attr='id')
     artist = indexes.CharField(model_attr='artist')
     pub_date = indexes.DateTimeField(model_attr='created_at')

--- a/soundcloud/track/search_indexes.py
+++ b/soundcloud/track/search_indexes.py
@@ -3,7 +3,7 @@ from track.models import Track
 
 
 class TrackIndex(indexes.SearchIndex, indexes.Indexable):
-    text = indexes.EdgeNgramField(document=True, use_template=True, template_name='search/track_text.txt')
+    q = indexes.EdgeNgramField(document=True, use_template=True, template_name='search/track_text.txt')
     id = indexes.IntegerField(model_attr='id')
     artist = indexes.CharField(model_attr='artist')
     pub_date = indexes.DateTimeField(model_attr='created_at')

--- a/soundcloud/track/search_indexes.py
+++ b/soundcloud/track/search_indexes.py
@@ -3,7 +3,8 @@ from track.models import Track
 
 
 class TrackIndex(indexes.SearchIndex, indexes.Indexable):
-    text = indexes.CharField(document=True, use_template=True, template_name='search/track_text.txt')
+    text = indexes.EdgeNgramField(document=True, use_template=True, template_name='search/track_text.txt')
+    id = indexes.IntegerField(model_attr='id')
     artist = indexes.CharField(model_attr='artist')
     pub_date = indexes.DateTimeField(model_attr='created_at')
 

--- a/soundcloud/track/search_indexes.py
+++ b/soundcloud/track/search_indexes.py
@@ -1,0 +1,15 @@
+from haystack import indexes
+from track.models import Track
+
+
+class TrackIndex(indexes.SearchIndex, indexes.Indexable):
+    text = indexes.CharField(document=True, use_template=True, template_name='search/track_text.txt')
+    artist = indexes.CharField(model_attr='artist')
+    pub_date = indexes.DateTimeField(model_attr='created_at')
+
+    def get_model(self):
+        return Track
+
+    def index_queryset(self, using=None):
+        """Used when the entire index for model is updated."""
+        return self.get_model().objects.all()

--- a/soundcloud/track/search_indexes.py
+++ b/soundcloud/track/search_indexes.py
@@ -5,6 +5,7 @@ from track.models import Track
 class TrackIndex(indexes.SearchIndex, indexes.Indexable):
     text = indexes.EdgeNgramField(document=True, use_template=True, template_name='search/track_text.txt')
     id = indexes.IntegerField(model_attr='id')
+    genre_name = indexes.CharField(model_attr='genre__name')
     artist = indexes.CharField(model_attr='artist')
     pub_date = indexes.DateTimeField(model_attr='created_at')
 

--- a/soundcloud/track/serializers.py
+++ b/soundcloud/track/serializers.py
@@ -368,4 +368,4 @@ class TrackSearchSerializer(HaystackSerializerMixin, TrackSerializer):
 
     class Meta(TrackSerializer.Meta):
         index_classes = [TrackIndex]
-        search_fields = ('text', )
+        search_fields = ('q', )

--- a/soundcloud/track/serializers.py
+++ b/soundcloud/track/serializers.py
@@ -368,4 +368,4 @@ class TrackSearchSerializer(HaystackSerializerMixin, TrackSerializer):
 
     class Meta(TrackSerializer.Meta):
         index_classes = [TrackIndex]
-        search_fields = ('q', )
+        search_fields = ('text', )

--- a/soundcloud/track/serializers.py
+++ b/soundcloud/track/serializers.py
@@ -2,6 +2,7 @@ from django.core.cache import cache
 from django.db import transaction
 from django.db.models import F
 from django.shortcuts import get_object_or_404
+from drf_haystack.serializers import HaystackSerializer, HaystackSerializerMixin
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers, status
@@ -12,6 +13,7 @@ from soundcloud.utils import get_presigned_url, MediaUploadMixin
 from tag.models import Tag
 from tag.serializers import TagSerializer
 from track.models import Track, TrackHit
+from track.search_indexes import TrackIndex
 from user.models import Follow
 from user.serializers import UserSerializer, SimpleUserSerializer
 from reaction.models import Like, Repost
@@ -360,3 +362,9 @@ class TrackHitService(serializers.Serializer):
             set_hit.save()
 
         return status.HTTP_200_OK, { 'client_ip': client_ip, 'xff': xff }
+
+
+class TrackSearchSerializer(HaystackSerializerMixin, TrackSerializer):
+    class Meta(TrackSerializer.Meta):
+        index_classes = [TrackIndex]
+        search_fields = ('text', )

--- a/soundcloud/track/serializers.py
+++ b/soundcloud/track/serializers.py
@@ -365,6 +365,7 @@ class TrackHitService(serializers.Serializer):
 
 
 class TrackSearchSerializer(HaystackSerializerMixin, TrackSerializer):
+
     class Meta(TrackSerializer.Meta):
         index_classes = [TrackIndex]
         search_fields = ('text', )

--- a/soundcloud/track/templates/search/track_text.txt
+++ b/soundcloud/track/templates/search/track_text.txt
@@ -1,0 +1,1 @@
+{{ object.title }}

--- a/soundcloud/track/templates/search/track_text.txt
+++ b/soundcloud/track/templates/search/track_text.txt
@@ -1,1 +1,3 @@
 {{ object.title }}
+{{ object.artist.display_name }}
+{{ object.description }}

--- a/soundcloud/track/urls.py
+++ b/soundcloud/track/urls.py
@@ -7,5 +7,5 @@ router.register('tracks', TrackViewSet, basename='tracks')
 
 urlpatterns = [
     path('', include(router.urls)),
-    path('search/track', TrackSearchAPIView.as_view(), name='search-track'),
+    path('search/tracks', TrackSearchAPIView.as_view(), name='search-tracks'),
 ]

--- a/soundcloud/track/urls.py
+++ b/soundcloud/track/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path, include
 from rest_framework.routers import SimpleRouter
-from track.views import TrackViewSet
+from track.views import TrackViewSet, TrackSearchAPIView
 
 router = SimpleRouter(trailing_slash=False)
 router.register('tracks', TrackViewSet, basename='tracks')
 
 urlpatterns = [
-    path('', include(router.urls))
+    path('', include(router.urls)),
+    path('search/track', TrackSearchAPIView.as_view(), name='search-track'),
 ]

--- a/soundcloud/track/views.py
+++ b/soundcloud/track/views.py
@@ -89,7 +89,7 @@ class TrackSearchAPIView(ListModelMixin, HaystackGenericAPIView):
         if ids:
             q &= Q(id__in=ids)
         if genres:
-            q &= Q(genre__in=genres)
+            q &= Q(genre_name__in=genres)
         if created_at:
             start = created_at.get('from', None)
             end = created_at.get('to', None)

--- a/soundcloud/track/views.py
+++ b/soundcloud/track/views.py
@@ -159,7 +159,6 @@ class TrackViewSet(viewsets.ModelViewSet):
 class TrackSearchAPIView(ListModelMixin, HaystackGenericAPIView):
     index_models = [Track]
     serializer_class = TrackSearchSerializer
-    pagination_class = None
 
     def get_queryset(self, index_models=[]):
         queryset = self.object_class()._clone()

--- a/soundcloud/track/views.py
+++ b/soundcloud/track/views.py
@@ -190,5 +190,12 @@ class TrackSearchAPIView(ListModelMixin, HaystackGenericAPIView):
 
         return queryset.filter(q)
 
+    @extend_schema(
+        summary="Search",
+        responses={
+            200: OpenApiResponse(response=TrackSearchSerializer, description='OK'),
+            400: OpenApiResponse(description='Bad Request'),
+        }
+    )
     def get(self, request, *args, **kwargs):
         return self.list(request, *args, **kwargs)

--- a/soundcloud/track/views.py
+++ b/soundcloud/track/views.py
@@ -1,6 +1,8 @@
 from django.db.models import Q
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_view
+from drf_haystack.viewsets import HaystackGenericAPIView, HaystackViewSet
+from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework import viewsets, permissions
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
@@ -8,7 +10,7 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 from soundcloud.utils import CustomObjectPermissions
 from track.models import Track
-from track.serializers import SimpleTrackSerializer, TrackHitService, TrackSerializer, TrackMediaUploadSerializer
+from track.serializers import SimpleTrackSerializer, TrackHitService, TrackSerializer, TrackMediaUploadSerializer, TrackSearchSerializer
 from user.models import User
 from user.serializers import SimpleUserSerializer
 
@@ -151,3 +153,12 @@ class TrackViewSet(viewsets.ModelViewSet):
         status, data = service.execute()
 
         return Response(status=status, data=data)
+
+
+class TrackSearchAPIView(ListModelMixin, HaystackGenericAPIView):
+    index_models = [Track]
+    serializer_class = TrackSearchSerializer
+    pagination_class = None
+
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)

--- a/soundcloud/user/search_indexes.py
+++ b/soundcloud/user/search_indexes.py
@@ -3,8 +3,10 @@ from user.models import User
 
 
 class UserIndex(indexes.SearchIndex, indexes.Indexable):
-    q = indexes.EdgeNgramField(document=True, use_template=True, template_name='search/track_text.txt')
+    text = indexes.EdgeNgramField(document=True, use_template=True, template_name='search/user_text.txt')
     id = indexes.IntegerField(model_attr='id')
+    city = indexes.CharField(model_attr='city')
+    country = indexes.CharField(model_attr='country')
 
     def get_model(self):
         return User

--- a/soundcloud/user/search_indexes.py
+++ b/soundcloud/user/search_indexes.py
@@ -1,0 +1,14 @@
+from haystack import indexes
+from user.models import User
+
+
+class UserIndex(indexes.SearchIndex, indexes.Indexable):
+    q = indexes.EdgeNgramField(document=True, use_template=True, template_name='search/track_text.txt')
+    id = indexes.IntegerField(model_attr='id')
+
+    def get_model(self):
+        return User
+
+    def index_queryset(self, using=None):
+        """Used when the entire index for model is updated."""
+        return self.get_model().objects.all()

--- a/soundcloud/user/serializers.py
+++ b/soundcloud/user/serializers.py
@@ -4,11 +4,13 @@ from django.contrib.auth.models import update_last_login
 from django.contrib.contenttypes.models import ContentType
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
+from drf_haystack.serializers import HaystackSerializerMixin
 from rest_framework import serializers, status
 from rest_framework_jwt.settings import api_settings
 from soundcloud.utils import ConflictError, MediaUploadMixin, get_presigned_url
 from datetime import date
 from track.models import Track
+from track.search_indexes import UserIndex
 from user.models import Follow
 
 # 토큰 사용을 위한 기본 세팅
@@ -330,4 +332,11 @@ class UserFollowService(serializers.Serializer):
 
         follow.delete()
         return status.HTTP_204_NO_CONTENT, "Successful"
+
+
+class UserSearchSerializer(HaystackSerializerMixin, UserSerializer):
+
+    class Meta(UserSerializer.Meta):
+        index_classes = [UserIndex]
+        search_fields = ('q', )
 

--- a/soundcloud/user/serializers.py
+++ b/soundcloud/user/serializers.py
@@ -10,7 +10,7 @@ from rest_framework_jwt.settings import api_settings
 from soundcloud.utils import ConflictError, MediaUploadMixin, get_presigned_url
 from datetime import date
 from track.models import Track
-from track.search_indexes import UserIndex
+from user.search_indexes import UserIndex
 from user.models import Follow
 
 # 토큰 사용을 위한 기본 세팅
@@ -338,5 +338,5 @@ class UserSearchSerializer(HaystackSerializerMixin, UserSerializer):
 
     class Meta(UserSerializer.Meta):
         index_classes = [UserIndex]
-        search_fields = ('q', )
+        search_fields = ('text', )
 

--- a/soundcloud/user/templates/search/user_text.txt
+++ b/soundcloud/user/templates/search/user_text.txt
@@ -1,0 +1,3 @@
+{{ object.display_name }}
+{{ object.first_name }}
+{{ object.last_name }}

--- a/soundcloud/user/urls.py
+++ b/soundcloud/user/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path, include
 from rest_framework.routers import SimpleRouter
 from .socialaccount import *
-from .views import UserSelfView, UserLoginView, UserSignUpView, UserLogoutView, UserViewSet, UserFollowView
+from .views import UserSelfView, UserLoginView, UserSignUpView, UserLogoutView, UserViewSet, UserFollowView, \
+    UserSearchAPIView
 
 router = SimpleRouter(trailing_slash=False)
 router.register('users', UserViewSet, basename='users')         # /users
@@ -13,5 +14,6 @@ urlpatterns = [
     path('users/me/followings/<int:user_id>', UserFollowView.as_view(), name='user-follow'),  # /users/me/followings/{user_id}
     path('users/me', UserSelfView.as_view(), name='user-self'), # /users/me
     path('', include(router.urls), name='user'),                # /users/{user_id}
-    path('socialaccount', SocialAccountApi.as_view(), name='social user signup/login'), #/socialaccount
+    path('socialaccount', SocialAccountApi.as_view(), name='social user signup/login'),       # /socialaccount
+    path('search/users', UserSearchAPIView.as_view(), name='search-users'),                 # /search/users
 ]

--- a/soundcloud/user/views.py
+++ b/soundcloud/user/views.py
@@ -348,12 +348,14 @@ class UserSearchAPIView(ListModelMixin, HaystackGenericAPIView):
         queryset = queryset.models(*self.index_models)
 
         ids = self.request.data.get('ids', None)
+        location = self.request.data.get('location', None)
 
         q = Q()
 
         if ids:
             q &= Q(id__in=ids)
-
+        if location:
+            q &= Q(city__in=location) | Q(country__in=location)
         return queryset.filter(q)
 
     @extend_schema(

--- a/soundcloud/user/views.py
+++ b/soundcloud/user/views.py
@@ -341,7 +341,6 @@ class UserFollowView(GenericAPIView):
 class UserSearchAPIView(ListModelMixin, HaystackGenericAPIView):
     index_models = [User]
     serializer_class = UserSearchSerializer
-    pagination_class = None
 
     def get_queryset(self, index_models=[]):
         queryset = self.object_class()._clone()

--- a/soundcloud/user/views.py
+++ b/soundcloud/user/views.py
@@ -1,9 +1,11 @@
 from django.contrib.auth import get_user_model, logout
-from django.db.models import F
+from django.db.models import Q
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_view
+from drf_haystack.viewsets import HaystackGenericAPIView
 from rest_framework import status, permissions, viewsets
 from rest_framework.filters import OrderingFilter
 from rest_framework.generics import GenericAPIView, CreateAPIView, RetrieveUpdateAPIView, get_object_or_404
+from rest_framework.mixins import ListModelMixin
 from rest_framework.response import Response
 from rest_framework.decorators import action
 from rest_framework.views import APIView
@@ -12,6 +14,7 @@ from comment.serializers import UserCommentSerializer
 from set.serializers import SimpleSetSerializer
 from track.serializers import SimpleTrackSerializer, UserTrackSerializer
 from user.serializers import *
+from datetime import datetime
 
 User = get_user_model()
 
@@ -333,3 +336,33 @@ class UserFollowView(GenericAPIView):
         status, data = service.delete()
 
         return Response(status=status, data=data)
+
+
+class UserSearchAPIView(ListModelMixin, HaystackGenericAPIView):
+    index_models = [User]
+    serializer_class = UserSearchSerializer
+    pagination_class = None
+
+    def get_queryset(self, index_models=[]):
+        queryset = self.object_class()._clone()
+        queryset = queryset.models(*self.index_models)
+
+        ids = self.request.data.get('ids', None)
+
+        q = Q()
+
+        if ids:
+            q &= Q(id__in=ids)
+
+        return queryset.filter(q)
+
+    @extend_schema(
+        summary="Search",
+        responses={
+            200: OpenApiResponse(response=UserSearchSerializer, description='OK'),
+            400: OpenApiResponse(description='Bad Request'),
+        }
+    )
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)
+


### PR DESCRIPTION
Search API 구현했습니다

url과 method가 다른 API와 겹쳐` GET /search/tracks, GET /search/sets, GET /search/users`로 url 변경했습니다

Search 구현을 위해 haystack, whoosh를 사용했습니다.

[GET /search/tracks](https://www.notion.so/Track-Search-9fbad3669a814e8d8332f3d1adc6d1f6) : text라는 query parameter에서 trackd의 title, artist의 display_name, description을 통해 검색 가능하도록 구현했습니다 (상세 request body는 노션에 적어놨습니다)

[GET /search/sets](https://www.notion.so/Set-Search-4f4a47e1b2e44a96bd528c7967a8c207) : text를 통해 sets의 title, creator, description의 내용을 통해 검색이 가능하도록 구현했습니다 (상세 request body는 노션에 적어놨습니다)

[GET /search/users](https://www.notion.so/User-Search-8c5b9fecbb6d40029f3f5ad96a9d8dea) : text를 통해 user의 display_name, first_name, last_name을 통해 검색이 가능하도록 구현했습니다 (상세 request body는 노션에 적어놨습니다)

deploy.sh에서 update_index 추가 했습니다

master 머지 후 처음 배포시에만 `python3 manage.py rebuild_index --noinput --settings=soundcloud.settings.prod `해주어야 합니다

indexing을 이용하는 검색이기 때문에 db상 update가 되어도 update_index를 해주지 않으면 검색이 불가능합니다. 따라서, 주기적으로 update_index를 해줘야 하는 것 같습니다

추가 구현 관련 

- GET search/tracks에서 duration은 조금 더 찾아보고 가능하면 구현해보겠습니다
- 정렬 순서를 못 정했는데 혹시 괜찮은 방식이 있을까요?

참고 문서

- [django-haystack readthedocs](https://django-haystack.readthedocs.io/en/master/toc.html)

- [drf-haystack readthedocs](https://drf-haystack.readthedocs.io/en/latest/)

- [장고(Django) 프로젝트에 검색기능 구현하기 -Haystack과 Whoosh를 이용한 기초 검색기능 구현-](https://medium.com/@whj2013123218/%EC%9E%A5%EA%B3%A0-django-%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8%EC%97%90-%EA%B2%80%EC%83%89%EA%B8%B0%EB%8A%A5-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0-haystack%EA%B3%BC-whoosh%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-%EA%B8%B0%EC%B4%88-%EA%B2%80%EC%83%89%EA%B8%B0%EB%8A%A5-%EA%B5%AC%ED%98%84-19aa7f8040db)

- [어서와, Django 검색은 처음이지?](https://parksunwoo.github.io/django/2021/01/25/welcome-django-search.html)